### PR TITLE
Added test_api.py script to test sentiment endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 scikit-learn
 joblib
+requests

--- a/test_api.py
+++ b/test_api.py
@@ -1,0 +1,8 @@
+import requests
+
+url = "http://127.0.0.1:8000/predict"
+data = {"text": "I love this!"}
+response = requests.post(url, json=data)
+
+print("Input Text:", data["text"])
+print("Prediction:", response.json())


### PR DESCRIPTION
This PR introduces a simple test_api.py script using the requests library. It sends a POST request to the /predict endpoint with sample text input and prints the result. It also adds requests to requirements.txt for local testing.